### PR TITLE
Case 27707; Fixed whitelist logic

### DIFF
--- a/includes/snippet.inc
+++ b/includes/snippet.inc
@@ -118,13 +118,12 @@ function _google_tag_data_layer_snippet() {
   $classes = [];
   $names = ['whitelist', 'blacklist'];
   foreach ($names as $name) {
-    $$name = explode("\n", $$name);
     if (empty($$name)) {
       continue;
     }
+    $$name = explode("\n", $$name);
     $classes["gtm.$name"] = $$name;
   }
-
   if ($classes) {
     // Build data layer snippet.
     $script = "var $data_layer = [" . json_encode($classes) . '];';


### PR DESCRIPTION
The whitelist was coming as empty, that was telling GTM to stop working
`<script>var dataLayer = [{"gtm.whitelist":[""],"gtm.blacklist":[""]}];</script>`
